### PR TITLE
postgres 10 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.1.64
+
+* added postgres 10 support for RHEL 6/7
+
 ## 0.1.63
 
 * set max_replication_slots to 5 by default

--- a/examples/demo_pg10.pp
+++ b/examples/demo_pg10.pp
@@ -1,0 +1,11 @@
+class { 'postgresql':
+  wal_level           => 'hot_standby',
+  max_wal_senders     => '3',
+  checkpoint_segments => '8',
+  wal_keep_segments   => '8',
+  version             => '10',
+}
+
+postgresql::pgdumpbackup { 'demobackup':
+  destination => '/tmp',
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,29 +21,35 @@ class postgresql::params {
       $datadir_default = {
                             '9.2' => '/var/lib/pgsql/9.2/data',
                             '9.6' => '/var/lib/pgsql/9.6/data',
+                            '10' => '/var/lib/pgsql/9.6/data',
                         }
 
       $packagename= {
                       '9.2' => [ 'postgresql92', 'postgresql92-server' ],
                       '9.6' => [ 'postgresql96', 'postgresql96-server' ],
+                      '10' => [ 'postgresql10', 'postgresql10-server' ],
                     }
 
       $servicename = {
                         '9.2' => 'postgresql-9.2',
                         '9.6' => 'postgresql-9.6',
+                        '10' => 'postgresql-10',
                       }
 
       $pidfile = {
                         '9.2' => '/var/lock/subsys/postgresql-9.2',
                         '9.6' => undef,
+                        '10' => undef,
                       }
       $initdb = {
                   '9.2' => '/usr/pgsql-9.2/bin/initdb',
                   '9.6' => '/usr/pgsql-9.6/bin/initdb',
+                  '10' => '/usr/pgsql-10/bin/initdb',
                 }
       $contrib = {
                   '9.2' => 'postgresql92-contrib',
                   '9.6' => 'postgresql96-contrib',
+                  '10' => 'postgresql10-contrib',
                 }
 
       case $::operatingsystem
@@ -58,10 +64,12 @@ class postgresql::params {
               $reposource =  {
                               '9.2' => 'https://download.postgresql.org/pub/repos/yum/9.2/redhat/rhel-6-x86_64/pgdg-redhat92-9.2-8.noarch.rpm',
                               '9.6' => 'https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-6-x86_64/pgdg-redhat96-9.6-3.noarch.rpm',
+                              '10' => 'https://download.postgresql.org/pub/repos/yum/10/redhat/rhel-6-x86_64/pgdg-redhat10-10-2.noarch.rpm',
                               }
               $reponame = {
                             '9.2' => 'pgdg-redhat92',
                             '9.6' => 'pgdg-redhat96',
+                            '10' => 'pgdg-redhat10',
                           }
             }
             /^7.*$/:
@@ -70,10 +78,12 @@ class postgresql::params {
                 $reposource =  {
                                 '9.2' => 'https://download.postgresql.org/pub/repos/yum/9.2/redhat/rhel-7-x86_64/pgdg-redhat92-9.2-3.noarch.rpm',
                                 '9.6' => 'https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-redhat96-9.6-3.noarch.rpm',
+                                '10' => 'https://download.postgresql.org/pub/repos/yum/10/redhat/rhel-7-x86_64/pgdg-redhat10-10-2.noarch.rpm',
                                 }
                 $reponame = {
                               '9.2' => 'pgdg-redhat92',
                               '9.6' => 'pgdg-redhat96',
+                              '10' => 'pgdg-redhat10',
                             }
               }
             default: { fail("Unsupported RHEL version! - ${::operatingsystemrelease}")  }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "eyp-postgresql",
-  "version": "0.1.63",
+  "version": "0.1.64",
   "author": "eyp",
   "summary": "postgresql installation and management",
   "license": "Apache-2.0",


### PR DESCRIPTION
[root@ip-172-31-36-160 puppet-masterless]# ./localpuppetmaster.sh -d /tmp/postgres -r https://github.com/jordiprats/eyp-postgresql -s /tmp/postgres/modules/postgresql/examples/demo_pg10.pp 

Checking Puppetfile syntax:
Syntax OK
Cleanup postgresql module
Warning: Missing dependency 'eyp-eyplib':
  'eyp-postgresql' (v0.1.64) requires 'eyp-eyplib' (>= 0.1.0 < 0.2.0)
Warning: Missing dependency 'eyp-lvm':
  'eyp-postgresql' (v0.1.64) requires 'eyp-lvm' (>= 0.1.0 < 0.2.0)
Warning: Missing dependency 'eyp-python':
  'eyp-postgresql' (v0.1.64) requires 'eyp-python' (>= 0.1.0 < 0.2.0)
Warning: Missing dependency 'eyp-systemd':
  'eyp-postgresql' (v0.1.64) requires 'eyp-systemd' (>= 0.1.35 < 0.2.0)
Warning: Missing dependency 'puppetlabs-concat':
  'eyp-postgresql' (v0.1.64) requires 'puppetlabs-concat' (>= 1.2.3 < 9.9.9)
Warning: Missing dependency 'puppetlabs-stdlib':
  'eyp-postgresql' (v0.1.64) requires 'puppetlabs-stdlib' (>= 4.12.0 < 9.9.9)
Notice: Preparing to uninstall 'eyp-postgresql' ...
Removed 'eyp-postgresql' (v0.1.64) from /tmp/postgres/modules
Installing puppet module using a Puppetfile
Installing dependencies
Dependencies installed
Warning: The string '1836.449219' was automatically coerced to the numerical value 1836.449219 (file: /tmp/postgres/modules/postgresql/manifests/init.pp, line: 32, column: 62)
Warning: The string '1836.449219' was automatically coerced to the numerical value 1836.449219 (file: /tmp/postgres/modules/postgresql/manifests/init.pp, line: 33, column: 70)
Warning: The string '4096' was automatically coerced to the numerical value 4096 (file: /tmp/postgres/modules/postgresql/manifests/init.pp, line: 33, column: 110)
Warning: The string '1836.449219' was automatically coerced to the numerical value 1836.449219 (file: /tmp/postgres/modules/postgresql/manifests/init.pp, line: 79, column: 77)
Warning: This method is deprecated, please use the stdlib validate_legacy function,
                    with Stdlib::Compat::Array. There is further documentation for validate_legacy function in the README. at ["/tmp/postgres/modules/postgresql/manifests/init.pp", 92]:
   (location: /tmp/postgres/modules/stdlib/lib/puppet/functions/deprecation.rb:28:in `deprecation')
Warning: This method is deprecated, please use the stdlib validate_legacy function,
                    with Stdlib::Compat::Bool. There is further documentation for validate_legacy function in the README. at ["/tmp/postgres/modules/postgresql/manifests/service.pp", 9]:
   (location: /tmp/postgres/modules/stdlib/lib/puppet/functions/deprecation.rb:28:in `deprecation')
Warning: This method is deprecated, please use the stdlib validate_legacy function,
                    with Pattern[]. There is further documentation for validate_legacy function in the README. at ["/tmp/postgres/modules/postgresql/manifests/service.pp", 13]:
   (location: /tmp/postgres/modules/stdlib/lib/puppet/functions/deprecation.rb:28:in `deprecation')
Warning: This method is deprecated, please use the stdlib validate_legacy function,
                    with Stdlib::Compat::Integer. There is further documentation for validate_legacy function in the README. at ["/tmp/postgres/modules/systemd/manifests/logind.pp", 33]:["/tmp/postgres/modules/systemd/manifests/init.pp", 27]
   (location: /tmp/postgres/modules/stdlib/lib/puppet/functions/deprecation.rb:28:in `deprecation')
Warning: This method is deprecated, please use the stdlib validate_legacy function,
                    with Stdlib::Compat::Absolute_Path. There is further documentation for validate_legacy function in the README. at ["/tmp/postgres/modules/postgresql/manifests/pgdumpbackup.pp", 26]:
   (location: /tmp/postgres/modules/stdlib/lib/puppet/functions/deprecation.rb:28:in `deprecation')
Notice: Compiled catalog for ip-172-31-36-160.eu-west-1.compute.internal in environment production in 0.34 seconds
Notice: /Stage[main]/Postgresql::Install/Exec[mkdir p /var/lib/pgsql/9.6/data]/returns: executed successfully
Notice: /Stage[main]/Postgresql::Install/File[/var/lib/pgsql/9.6/data]/owner: owner changed 'root' to 'postgres'
Notice: /Stage[main]/Postgresql::Install/File[/var/lib/pgsql/9.6/data]/group: group changed 'root' to 'postgres'
Notice: /Stage[main]/Postgresql::Install/File[/var/lib/pgsql/9.6/data]/mode: mode changed '0755' to '0700'
Notice: /Stage[main]/Postgresql::Install/File[/var/lib/pgsql/9.6/data]/seluser: seluser changed 'unconfined_u' to 'system_u'
Notice: /Stage[main]/Postgresql::Install/Exec[initdb postgresql]/returns: executed successfully
Notice: /Stage[main]/Postgresql::Config/File[/etc/sysconfig/pgsql/postgresql-10]/ensure: defined content as '{md5}fd9583b03af3f4e621082e8724406f0d'
Notice: /Stage[main]/Postgresql::Config/File[/etc/profile.d/psql.sh]/ensure: defined content as '{md5}f06a237d0315f3674c7bf77e65b81554'
Notice: /Stage[main]/Systemd::Logind/File[/etc/systemd/logind.conf]/content: content changed '{md5}93fc6521ad0d2e55ac80cd65803ca324' to '{md5}910a528717e4d0694790b2d0436e44f8'
Notice: /Stage[main]/Postgresql::Config/Systemd::Service::Dropin[postgresql-10]/File[/etc/systemd/system/postgresql-10.service.d/]/ensure: created
Notice: /Stage[main]/Postgresql::Config/Systemd::Service::Dropin[postgresql-10]/File[/etc/systemd/system/postgresql-10.service.d/99-override.conf]/ensure: defined content as '{md5}15caca189b63792a9b0e900f8c014325'
Notice: /Stage[main]/Systemd/Exec[systemctl daemon-reload]: Triggered 'refresh' from 3 events
Notice: /Stage[main]/Postgresql::Config/Concat[/var/lib/pgsql/9.6/data/postgresql.conf]/File[/var/lib/pgsql/9.6/data/postgresql.conf]/content: content changed '{md5}267fb40adf184bbd8ec9c3ff8c0930f3' to '{md5}c96a73aeb0de74083f7230d5853918c3'
Notice: /Stage[main]/Postgresql::Config/Concat[/var/lib/pgsql/9.6/data/postgresql.conf]/File[/var/lib/pgsql/9.6/data/postgresql.conf]/seluser: seluser changed 'unconfined_u' to 'system_u'
Notice: /Stage[main]/Postgresql::Config/Concat[/var/lib/pgsql/9.6/data/pg_hba.conf]/File[/var/lib/pgsql/9.6/data/pg_hba.conf]/content: content changed '{md5}ec9940fccbfe954347717ddaf0f79c39' to '{md5}3304d466b7d2145d0e7b0b6ccd94fd86'
Notice: /Stage[main]/Postgresql::Config/Concat[/var/lib/pgsql/9.6/data/pg_hba.conf]/File[/var/lib/pgsql/9.6/data/pg_hba.conf]/seluser: seluser changed 'unconfined_u' to 'system_u'
Notice: /Stage[main]/Postgresql::Service/Service[postgresql-10]/ensure: ensure changed 'stopped' to 'running'
Notice: /Stage[main]/Main/Postgresql::Pgdumpbackup[demobackup]/File[/usr/local/bin/pgdumpbackup.sh]/ensure: defined content as '{md5}1b2c467010bae51ac5390dc877e593c7'
Notice: /Stage[main]/Main/Postgresql::Pgdumpbackup[demobackup]/File[/usr/local/bin/pgdumpbackup.config]/ensure: defined content as '{md5}ff298c220f41b4b6ba15e6b9138a0340'
Notice: /Stage[main]/Main/Postgresql::Pgdumpbackup[demobackup]/File[/tmp]/group: group changed 'root' to 'postgres'
Notice: /Stage[main]/Main/Postgresql::Pgdumpbackup[demobackup]/File[/tmp]/mode: mode changed '1777' to '0770'
Notice: /Stage[main]/Main/Postgresql::Pgdumpbackup[demobackup]/Cron[cronjob logical postgres backup: demobackup]/ensure: created
Notice: Applied catalog in 2.90 seconds
[root@ip-172-31-36-160 puppet-masterless]# psql -U postgres
psql (10.6)
Type "help" for help.

postgres=# \l
                                  List of databases
   Name    |  Owner   | Encoding |   Collate   |    Ctype    |   Access privileges   
-----------+----------+----------+-------------+-------------+-----------------------
 postgres  | postgres | UTF8     | en_US.UTF-8 | en_US.UTF-8 | 
 template0 | postgres | UTF8     | en_US.UTF-8 | en_US.UTF-8 | =c/postgres          +
           |          |          |             |             | postgres=CTc/postgres
 template1 | postgres | UTF8     | en_US.UTF-8 | en_US.UTF-8 | =c/postgres          +
           |          |          |             |             | postgres=CTc/postgres
(3 rows)

postgres=# 
